### PR TITLE
disable temp_psi4_geom.xyz file generation

### DIFF
--- a/src/commandline.py
+++ b/src/commandline.py
@@ -24,9 +24,10 @@ def stop_watch(func):
 
 @stop_watch
 def run_hf_ksdft():
-  nuclear_numbers, geom_coordinates, basis_set_name, ksdft_functional_name = conf.get_calc_params()
-  calc_mol = hf_ksdft.driver(nuclear_numbers, geom_coordinates,
-                    basis_set_name, ksdft_functional_name)
+  mol_xyz, nuclear_numbers, geom_coordinates, basis_set_name, ksdft_functional_name = conf.get_calc_params()
+  calc_mol = hf_ksdft.driver(mol_xyz, nuclear_numbers,
+                    geom_coordinates, basis_set_name,
+                    ksdft_functional_name)
   calc_mol.scf()
 
 

--- a/src/hf_ksdft.py
+++ b/src/hf_ksdft.py
@@ -3,7 +3,8 @@ import interface_psi4 as ipsi4
 
 
 class driver():
-  def __init__(self, nuclear_numbers, geom_coordinates, basis_set_name, ksdft_functional_name):
+  def __init__(self, mol_xyz, nuclear_numbers, geom_coordinates, basis_set_name, ksdft_functional_name):
+    self._mol_xyz = mol_xyz
     self._nuclear_numbers = nuclear_numbers
     self._geom_coordinates = geom_coordinates
     self._basis_set_name = basis_set_name
@@ -61,8 +62,9 @@ class driver():
     ### Preprocessing for SCF
 
     proc_ao_integral = ipsi4.proc_psi4(
-        self._nuclear_numbers, self._geom_coordinates,
-        self._basis_set_name, self._ksdft_functional_name)
+        self._mol_xyz, self._nuclear_numbers,
+        self._geom_coordinates, self._basis_set_name,
+        self._ksdft_functional_name)
 
     # Compute all requisite analytical AO integrations
     ao_kinetic_integral = proc_ao_integral.ao_kinetic_integral()

--- a/src/interface_psi4.py
+++ b/src/interface_psi4.py
@@ -11,9 +11,7 @@ def gener_psi4_geom(nuclear_numbers, geom_coordinates):
 
 
 class proc_psi4():
-  def __init__(self, nuclear_numbers, geom_coordinates, basis_set_name, ksdft_functional_name):
-    # This redundant operation will be removed.
-    mol_xyz = open('temp_psi4_geom.xyz', mode='r').read()
+  def __init__(self, mol_xyz, nuclear_numbers, geom_coordinates, basis_set_name, ksdft_functional_name):
     mol = psi4.geometry(mol_xyz)
 
     # symbol_nuclear_numbers = gener_psi4_geom(nuclear_numbers, geom_coordinates)

--- a/src/setting.py
+++ b/src/setting.py
@@ -11,6 +11,7 @@ def read_xyz(xyz_file_name):
   coordinates = []
 
   count = 0
+  mol_xyz = ''
   for line in xyz_lines:
     count += 1
     if count == 1:
@@ -18,6 +19,7 @@ def read_xyz(xyz_file_name):
     elif count > 2:
       if len(line) == 0:
           break
+      mol_xyz += str(line)
       parts = line.split()
       try:
           nuclear_numbers.append(int(parts[0]))
@@ -25,21 +27,7 @@ def read_xyz(xyz_file_name):
           nuclear_numbers.append(lut.element_Z_from_sym(parts[0]))
       coordinates.append([float(_) for _ in parts[1:4]])
 
-  # This will be removed.
-  # Just to handle the PSI4's special input for the geometry.
-  with open('temp_psi4_geom.xyz', mode='w') as fh:
-    count = 0
-    for line in xyz_lines:
-      count += 1
-      if count == 1 or count == 2:
-        pass
-      else:
-        if len(line) == 0:
-          break
-        print(line.replace("\n", ''), file=fh)
-
-  return np.array(nuclear_numbers), np.array(coordinates)
-
+  return mol_xyz, np.array(nuclear_numbers), np.array(coordinates)
 
 def get_calc_params():
   """ Get parameters for the calculation.
@@ -55,6 +43,6 @@ def get_calc_params():
   basis_set_name = sqc_conf['calc']['gauss_basis_set']
   ksdft_functional_name = sqc_conf['calc']['ksdft_functional']
 
-  nuclear_numbers, geom_coordinates = read_xyz(xyz_file_name)
+  mol_xyz, nuclear_numbers, geom_coordinates = read_xyz(xyz_file_name)
 
-  return nuclear_numbers, geom_coordinates, basis_set_name, ksdft_functional_name
+  return mol_xyz, nuclear_numbers, geom_coordinates, basis_set_name, ksdft_functional_name


### PR DESCRIPTION
Add mol_xyz variable instead of generating temp_psi4_geom.xyz file and simplify mol = psi4.geometry() function in the interface_psi4.py.